### PR TITLE
Some tweaks to interface-http.

### DIFF
--- a/interface_http.py
+++ b/interface_http.py
@@ -3,7 +3,12 @@ import json
 from ops.framework import EventBase, EventsBase, EventSource, Object, StoredState
 
 
-class NewClient(EventBase):
+class NewClientEvent(EventBase):
+    """Emitted when a new unit joins a relation with the HTTP endpoint.
+
+    :var client: The client that is connecting at this time.
+    :type client: HTTPInterfaceClient
+    """
     def __init__(self, handle, client):
         super().__init__(handle)
         self.client = client
@@ -20,40 +25,58 @@ class NewClient(EventBase):
 
 
 class HTTPServerEvents(EventsBase):
-    new_client = EventSource(NewClient)
+    """These are the events that can be emitted by HTTPServer."""
+    new_client = EventSource(NewClientEvent)
 
 
 class HTTPServer(Object):
+    """Represents the Provides side of an 'http' relation.
+
+    Will emit() self.on.new_client when a unit joins a relation with this endpoint.
+    The event emitted will be a NewClientEvent which has attribute .client
+    describing who joined the relation.
+
+    You can also look at .clients() to get the complete list of all connected clients.
+    """
+
     on = HTTPServerEvents()
-    state = StoredState()
+    _stored = StoredState()
 
     def __init__(self, charm, relation_name):
-        super().__init__(charm, relation_name)
-        self.relation_name = relation_name
-        self.framework.observe(charm.on.start, self.init_state)
-        self.framework.observe(charm.on[relation_name].relation_joined, self.on_joined)
-        self.framework.observe(charm.on[relation_name].relation_departed, self.on_departed)
+        """Initialize handling of the provides side of an 'http' interface.
 
-    def init_state(self, event):
-        self.state.apps = []
+        :param charm: the CharmBase using the http interface.
+        :param relation_name: the name of the interface.
+        """
+        super().__init__(charm, relation_name)
+        self._relation_name = relation_name
+        self._stored.set_default('apps', [])
+        self.framework.observe(charm.on[relation_name].relation_joined, self._on_joined)
+        self.framework.observe(charm.on[relation_name].relation_departed, self._on_departed)
 
     @property
     def _relations(self):
-        return self.model.relations[self.relation_name]
+        return self.model.relations[self._relation_name]
 
-    def on_joined(self, event):
-        if event.app not in self.state.apps:
+    def _on_joined(self, event):
+        if event.app not in self._stored.apps:
             self.state.apps.append(event.app)
             self.on.new_client.emit(HTTPInterfaceClient(event.relation, self.model.unit))
 
-    def on_departed(self, event):
+    def _on_departed(self, event):
         self.state.apps = [app for app in self._relations]
 
     def clients(self):
+        """Get the list of all clients of this HTTP server."""
         return [HTTPInterfaceClient(relation, self.model.unit) for relation in self._relations]
 
 
 class HTTPInterfaceClient:
+    """Identifies a remote unit that has joined a relation to this HTTP Server.
+
+    This will be an attribute of NewClientEvent, which happens when someone joins the HTTP
+    relation.
+    """
     def __init__(self, relation, local_unit):
         self._relation = relation
         self._local_unit = local_unit
@@ -64,3 +87,4 @@ class HTTPInterfaceClient:
             'hostname': host,
             'port': port,
         } for host in hosts])
+


### PR DESCRIPTION
The only functional change is renaming NewClient to NewClientEvent.
The rest should just be making methods private that we don't want users
accessing, and documenting the public interfaces.
Also renaming .state to ._stored to make it clearer that this is the
state-of-the-component that is persisted to disk.

This came out of a conversation with Tim McNamara (@timclicks) about 'what is the public api for this interface', and realizing that our standard practice of how we were writing Interfaces wasn't clear. The idea is to change event handlers to private methods, and add some documentation about the expected use of the interface.

I wrote this up as part of thinking through how we might make it clearer. I'm not settled on any of it, but since I had done the effort, I figured I might as well make a PR.